### PR TITLE
Browser compatible

### DIFF
--- a/ConstructorIcon.svelte
+++ b/ConstructorIcon.svelte
@@ -1,16 +1,20 @@
-<svelte:options tag={null}/>
+<svelte:options/>
 
 <script lang="ts">
-    export let commitExpression
-    export let discard
-
     let text = ""
+    function commitExpression(e) {
+        e.target.dispatchEvent(new CustomEvent('commitExpression', { detail: { text }, composed:true }))
+    }
 
+    function discard(e) {
+        text = ""
+        e.target.dispatchEvent(new CustomEvent('discard', { composed:true }))
+    }
 </script>
 
 <div class="container">
     <input bind:value={text}>
-    <button on:click={()=>commitExpression(text)}>Commit</button>
+    <button on:click={commitExpression}>Commit</button>
     <button on:click={discard}>Discard</button>
 </div>
 

--- a/Icon.svelte
+++ b/Icon.svelte
@@ -1,10 +1,16 @@
 <svelte:options/>
 
 <script lang="ts">
-    import type Expression from "@perspect3vism/ad4m/Expression";
-    export let expression: Expression
+    export let expression: string;
     let string
-    $: if(expression && expression.data) string = JSON.parse(expression.data)
+    $: if(expression) {
+        const parsed = JSON.parse(expression)
+        if (parsed.data) {
+            string = JSON.parse(parsed.data)
+        } else {
+            string = parsed
+        }
+    }
 </script>
 
 <div class="container">

--- a/Icon.svelte
+++ b/Icon.svelte
@@ -1,4 +1,4 @@
-<svelte:options tag={null}/>
+<svelte:options/>
 
 <script lang="ts">
     import type Expression from "@perspect3vism/ad4m/Expression";

--- a/rollup.config.icons.js
+++ b/rollup.config.icons.js
@@ -11,8 +11,8 @@ export default [
 {
 	input: 'ConstructorIcon.svelte',
 	output: {
-		sourcemap: true,
-		format: 'cjs',
+		sourcemap: false,
+		format: 'es',
 		name: 'ConstructorIcon',
 		file: 'build/ConstructorIcon.js'
 	},
@@ -59,8 +59,8 @@ export default [
 {
 	input: 'Icon.svelte',
 	output: {
-		sourcemap: true,
-		format: 'cjs',
+		sourcemap: false,
+		format: 'es',
 		name: 'Icon',
 		file: 'build/Icon.js'
 	},


### PR DESCRIPTION
Contains changes to the constructor icon to use events instead of getting functions as props as it doesn't work with web-components and updated rollup-config for icons.